### PR TITLE
Fix elems to show build status

### DIFF
--- a/pr-build-status-in-favicon/pr-build-status-in-favicon.user.js
+++ b/pr-build-status-in-favicon/pr-build-status-in-favicon.user.js
@@ -19,7 +19,7 @@ observer.observe(document.body, { childList: true, subtree: true });
 
 function update() {
   var buildStatusColor = (function () {
-    var elems = $$('.timeline-commits .commit-meta .status');
+    var elems = $$('.branch-status .octicon');
     var elem = elems[elems.length - 1];
     if (!elem) return null;
     return getComputedStyle(elem).color;


### PR DESCRIPTION
"pr-build-status-in-favicon" does not work :scream_cat: 
So I fix it :+1: 
I think some GitHub's html elements has been modified, and can not get status by `$$('.timeline-commits .commit-meta .status');`.
